### PR TITLE
Add UnfoldCMS - self-hosted headless CMS for JAMstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of awesome JAMstack starters, workflows, articles, resources and sh
 
 ## Content management systems
  - [Tipe](https://tipe.io/) - API-first design with GraphQL or REST API
+ - [UnfoldCMS](https://unfoldcms.com) - Self-hosted CMS with REST API v1, HMAC webhooks, and headless mode for Next.js, Astro, SvelteKit, and Nuxt. ([Source Code](https://github.com/hpakdaman/unfoldcms))
 
 
 ## Community


### PR DESCRIPTION
## Add UnfoldCMS

[UnfoldCMS](https://github.com/hpakdaman/unfoldcms) is a self-hosted CMS built on Laravel 12 + React 19 + shadcn/ui.

**Key features:**
- REST API v1 with full CRUD, Sanctum auth
- HMAC-signed outgoing webhooks
- Headless mode — works with Next.js, Astro, SvelteKit, Nuxt
- Clean shadcn/ui admin panel
- Self-hosted, source-available
- Live demo: https://demo.unfoldcms.com

Fits this list as a headless CMS powering JAMstack frontends via its REST API v1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added UnfoldCMS to the list of supported content management systems, including details about its REST API, HMAC webhooks, and headless capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->